### PR TITLE
Fix broken links to FSCP

### DIFF
--- a/pages/html/compliance/how-to-inventory-a.html
+++ b/pages/html/compliance/how-to-inventory-a.html
@@ -1,6 +1,6 @@
 <h1 id="creatingyourenterprisecodeinventory">Creating your enterprise code inventory</h1>
 <h2 id="overview">Overview</h2>
-<p>Section <a href="#code-inventories-and-discovery">7.2</a> and <a href="#codegov">7.3</a> of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.</p>
+<p>Section <a href="/policy-guide/implementation#72codeinventoriesanddiscovery">7.2</a> and <a href="/policy-guide/implementation#73codegov">7.3</a> of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.</p>
 <p>Using these inventories, <a href="https://Code.gov">Code.gov</a> will provide a platform to search federally funded open source software and software available for government-wide reuse.</p>
 <h2 id="publishingyouragencysinventory">Publishing Your Agency's Inventory</h2>
 <p>Agencies are required to publish their inventories using a standard metadata schema - a JSON file that they'll make available on their agency websites.  Agencies are strongly encouraged to use version 2.0.0 of the schema, which is described below. This version includes revisions that make your inventory much more useful and intuitive.</p>

--- a/pages/html/open-source-pilot/introduction.html
+++ b/pages/html/open-source-pilot/introduction.html
@@ -1,7 +1,7 @@
 <h1 id="introductionbuildingyouragencysopensourcepractice">Introduction - Building Your Agency's Open Source Practice</h1>
 <p><a href="https://code.gov/policy-guide/open-source">Section 5 of the Federal Source Code Policy</a> outlines an Open Source Pilot Program that requires the release of a portion of Federal source code over three years. This section of code.gov provides advice for agencies in satisfying the requirements of the pilot.</p>
 <p>The open source practice for the U.S. government is expected to rapidly evolve and become more sophisticated over the next several years, so the advice provided here will also evolve.</p>
-<p>In addition to the requirements outline in <a href="https://code.gov/policy-guide/open-source">Section 5</a> of the policy, <a href="#roles-and-responsibilities">Section 7.1</a> of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:</p>
+<p>In addition to the requirements outline in <a href="https://code.gov/policy-guide/open-source">Section 5</a> of the policy, <a href="/policy-guide/implementation#71rolesandresponsibilities">Section 7.1</a> of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:</p>
 <blockquote>
   <p>Agencies should strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations.</p>
 </blockquote>
@@ -9,7 +9,7 @@
 <h2 id="engagedandsupportiveagencyleadership">Engaged and supportive agency leadership</h2>
 <p>Agencies and teams that have been most successful in establishing their open source practice have benefited from engaged and supportive agency leadership who have helped teams navigate key legal, security, and operational issues. Strong engagement from the agency CIO and other leadership can have the effect of convening the necessary stakeholders to have a serious conversation. It can also greatly accelerate the establishment of clear, repeatable processes and foundational policy. With this foundation in place, your agency's teams can refine policy and process as they learn together.</p>
 <h2 id="opensourceisaninterdisciplinarypractice">Open Source is an interdisciplinary practice</h2>
-<p><a href="#roles-and-responsibilities">Section 7.1</a> of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:</p>
+<p><a href="/policy-guide/implementation#71rolesandresponsibilities">Section 7.1</a> of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:</p>
 <blockquote>
   <p>[..] agency heads must ensure that CIOs and Senior Agency Officials,including CAOs, are positioned with the responsibility and authority necessary to implement the requirements of this policy. As appropriate, Senior Agency Officials should also work with the agency’s public affairs staff, open government staff, web manager or digital strategist, program owners, and other leadership to properly identify, publish, and collaborate with communities on their OSS projects.</p>
 </blockquote>

--- a/pages/html/open-source-pilot/tools-and-resources.html
+++ b/pages/html/open-source-pilot/tools-and-resources.html
@@ -1,5 +1,5 @@
 <h1 id="toolsandresources">Tools and Resources</h1>
-<p><a href="#code-repositories">Section 7.4</a>&nbsp;of the Federal Source Code Policy states:</p>
+<p><a href="/policy-guide/implementation#74coderepositories">Section 7.4</a>&nbsp;of the Federal Source Code Policy states:</p>
 <blockquote>
   <p>Accessible, buildable, version-controlled repositories for the storage, discussion, and modification of custom-developed code are critical to both the Government-wide reuse and OSS pilot program sections of this policy. Agencies should utilize existing code repositories and common third-party repository platforms as necessary in order to satisfy the requirements of this policy.</p>
 </blockquote>

--- a/pages/html/overview/tracking-progress.html
+++ b/pages/html/overview/tracking-progress.html
@@ -1,5 +1,5 @@
 <h1 id="howombwillassessagencyprogress">How OMB Will Assess Agency Progress</h1>
-<p><a href="#accountability-mechanisms">Section 7.7</a> of the Federal Source Code Policy states that:</p>
+<p><a href="/policy-guide/implementation#77accountabilitymechanisms">Section 7.7</a> of the Federal Source Code Policy states that:</p>
 <blockquote>
   <p>Progress on agency implementation of this policy will be primarily assessed by OMB through an analysis of each agency’s internal Government repositories, public OSS repositories, and code inventories on Code.gov, as well as data obtained through the quarterly Integrated Data Collection (IDC), quarterly PortfolioStat sessions, the IT Dashboard, and additional mechanisms [..]</p>
 </blockquote>

--- a/pages/markdown/compliance/how-to-inventory-a.md
+++ b/pages/markdown/compliance/how-to-inventory-a.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Section [7.2](#code-inventories-and-discovery) and [7.3](#codegov) of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.
+Section [7.2](/policy-guide/implementation#72codeinventoriesanddiscovery) and [7.3](/policy-guide/implementation#73codegov) of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.
 
 Using these inventories, [Code.gov](https://Code.gov) will provide a platform to search federally funded open source software and software available for government-wide reuse.
 

--- a/pages/markdown/open-source-pilot/introduction.md
+++ b/pages/markdown/open-source-pilot/introduction.md
@@ -4,7 +4,7 @@
 
 The open source practice for the U.S. government is expected to rapidly evolve and become more sophisticated over the next several years, so the advice provided here will also evolve.
 
-In addition to the requirements outline in [Section 5](https://code.gov/policy-guide/open-source) of the policy, [Section 7.1](#roles-and-responsibilities) of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:
+In addition to the requirements outline in [Section 5](https://code.gov/policy-guide/open-source) of the policy, [Section 7.1](/policy-guide/implementation#71rolesandresponsibilities) of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:
 
 > Agencies should strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations.
 
@@ -16,7 +16,7 @@ Agencies and teams that have been most successful in establishing their open sou
 
 ## Open Source is an interdisciplinary practice
 
-[Section 7.1](#roles-and-responsibilities) of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:
+[Section 7.1](/policy-guide/implementation#71rolesandresponsibilities) of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:
 
 > [..] agency heads must ensure that CIOs and Senior Agency Officials,including CAOs, are positioned with the responsibility and authority necessary to implement the requirements of this policy. As appropriate, Senior Agency Officials should also work with the agency’s public affairs staff, open government staff, web manager or digital strategist, program owners, and other leadership to properly identify, publish, and collaborate with communities on their OSS projects.
 

--- a/pages/markdown/open-source-pilot/tools-and-resources.md
+++ b/pages/markdown/open-source-pilot/tools-and-resources.md
@@ -1,6 +1,6 @@
 # Tools and Resources
 
-[Section 7.4](#code-repositories) of the Federal Source Code Policy states:
+[Section 7.4](/policy-guide/implementation#74coderepositories) of the Federal Source Code Policy states:
 
 > Accessible, buildable, version-controlled repositories for the storage, discussion, and modification of custom-developed code are critical to both the Government-wide reuse and OSS pilot program sections of this policy. Agencies should utilize existing code repositories and common third-party repository platforms as necessary in order to satisfy the requirements of this policy.
 

--- a/pages/markdown/overview/tracking-progress.md
+++ b/pages/markdown/overview/tracking-progress.md
@@ -1,6 +1,6 @@
 # How OMB Will Assess Agency Progress
 
-[Section 7.7](#accountability-mechanisms) of the Federal Source Code Policy states that:
+[Section 7.7](/policy-guide/implementation#77accountabilitymechanisms) of the Federal Source Code Policy states that:
 
 > Progress on agency implementation of this policy will be primarily assessed by OMB through an analysis of each agency’s internal Government repositories, public OSS repositories, and code inventories on Code.gov, as well as data obtained through the quarterly Integrated Data Collection (IDC), quarterly PortfolioStat sessions, the IT Dashboard, and additional mechanisms \[..\]
 


### PR DESCRIPTION
## Why?
- https://github.com/GSA/code-gov-front-end/issues/141
- https://github.com/GSA/code-gov-front-end/issues/142
- https://github.com/GSA/code-gov-front-end/issues/143
- https://github.com/GSA/code-gov-fscp-react-component/issues/8

## What Changed?
- updated broken links in html and markdown files

## Note
These changes resolve the various broken link issues. To make these changes visible on the front end, you need to run a fresh `npm install` after the about page version bump (with the updated version number), then run the `npm run install-about-plugin` command to update the html assets.